### PR TITLE
Added poor support for flashing .bin firmwares to `nodeupgrade`

### DIFF
--- a/util/nodeupgrade/files/nodeupgrade
+++ b/util/nodeupgrade/files/nodeupgrade
@@ -67,6 +67,7 @@ EOF
 include /lib/upgrade
 
 image_type() {
+	# TODO: This should probably be called partition detection, type detection should instead be based on file extensions
 	local base="$(basename "$1")"
 	base=${base%.*}
 	local length=$(( ${#base} - 23 ))
@@ -82,7 +83,9 @@ image_type() {
 		kernel)
 			;;
 		*)
-			base=""
+			# Use file extension  # XXX: Mixing partitions and file types (check code elsewhere for '"bin"' or 'bin)')
+			base="$(basename "$1")"
+			base=${base##*.}
 			;;
 	esac
 	type=$base
@@ -128,7 +131,13 @@ remote_file_hostname() {
 }
 
 check_partitions() {
-	if [[ "$IMAGES_COUNT" -eq 1 ]]; then
+	# TODO: Partitions should be part of file names
+	if [[ "$IMAGES_COUNT" -eq 1 && "$type" == "bin" ]]; then  # TODO: Should probably be done differently
+		if ! grep -q -E '"firmware"$' /proc/mtd 2>/dev/null; then
+			echo "Missing required partition(s)."
+			exit 1
+		fi
+	elif [[ "$IMAGES_COUNT" -eq 1 ]]; then
 		if ! grep -q -E '"linux"$' /proc/mtd 2>/dev/null; then
 			echo "Missing required partition(s)."
 			exit 1
@@ -237,6 +246,9 @@ check_image() {
 			;;
 		kernel)
 			check_lzma "$image" || return 1
+			;;
+		bin)
+			check_bin "$image" || return 1
 			;;
 		*)
 			check_trx "$image" || return 1
@@ -400,12 +412,15 @@ for image in $IMAGES; do
 	# We first check for image type as this also checks for image filename length
 	image_type "$image"
 	if [[ "$IMAGES_COUNT" -eq 1 ]]; then
-		if [[ -n "$type" ]]; then
-			echo "Invalid image type or missing image filename argument."
-			exit 1
-		fi
-
-		FLASH_IMAGE="$image"
+		case "$type" in
+			bin)
+				FLASH_IMAGE="$image"
+				;;
+			*)  # "root" or "kernel"
+				echo "Invalid image type or missing image filename argument."
+				exit 1
+				;;
+		esac
 	elif [[ -n "$ROOT_IMAGE" ]]; then
 		case "$type" in
 			root)

--- a/util/nodeupgrade/files/nodeupgrade.sh
+++ b/util/nodeupgrade/files/nodeupgrade.sh
@@ -38,8 +38,13 @@ node_upgrade() {
 	fi
 	
 	if [[ -n "$FLASH_IMAGE" ]]; then
-		echo "Flashing '$FLASH_IMAGE'."
-		mtd $CONF_TGZ write "$FLASH_IMAGE" linux || flashing_failed
+		if [[ "${FLASH_IMAGE##*.}" == "bin" ]]; then  # TODO: Should probably be done differently
+			echo "Flashing '$FLASH_IMAGE'."
+			mtd $CONF_TGZ write "$FLASH_IMAGE" firmware || flashing_failed
+		else
+			echo "Flashing '$FLASH_IMAGE'."
+			mtd $CONF_TGZ write "$FLASH_IMAGE" linux || flashing_failed
+		fi
 	else
 		if [[ -n "$KERNEL_IMAGE" ]]; then
 			echo "Flashing '$KERNEL_IMAGE'."


### PR DESCRIPTION
I made some minor improvements to `nodeupgrade` and added poor support for flashing `.bin` firmware files.

It flashes the TL-WRT741ND v2.4 router correctly with `wlan slovenija` firmware, but it later gives an error because of `mtd -j $CONF_TGZ` parameter for preserving configuration that seems to work only with JFFS2 and it consequently returns an error.

In my opinion the code needs some refactoring and should be simplified. The simplification is related to changing the convention for creating file names and some thoughts about this are on http://dev.wlan-si.net/ticket/1059#comment:3.

To sum up:
- exact partition names should be put in file names (not user friendly strings)
- file extensions should be used for detecting firmware image types
- optionally there could also be an alternative way of passing this information instead of actual file names (like appending query string like syntax, eg. `?partition=firmware&type=bin`, `?partition=rootfs&type=jffs2-64k`)

If you think this is naming convention change is reasonable, a new ticket should be open...
