### PR TITLE
nodewatcher-agent: write json output feed to /tmp

### DIFF
--- a/util/nodewatcher-agent/Makefile
+++ b/util/nodewatcher-agent/Makefile
@@ -54,6 +54,8 @@ define Package/nodewatcher-agent/install
 	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d
 	$(INSTALL_CONF) ./files/rpcd-acl.json $(1)/usr/share/rpcd/acl.d/nodewatcher.json
 	$(INSTALL_DIR) $(1)/www/nodewatcher
+	# add symbolic link to write json output feed to /tmp instead of overlayfs (since flash has limited erase cycles)
+	ln -s /tmp/nodewatcher_feed $(1)/www/nodewatcher/feed
 endef
 
 


### PR DESCRIPTION
For nodewatcher-agent default openwrt configuration writes json output to /www/nodewatcher/feed, but that means it writes output to flash every few minutes and it would make it wear out very soon.
It would be better to add symbolic link to write output to /tmp/nodewatcher_feed.