### PR TITLE
tunneldigger.init: add support for multiple tunneldigger sections

### DIFF
--- a/net/tunneldigger/files/tunneldigger.init
+++ b/net/tunneldigger/files/tunneldigger.init
@@ -8,56 +8,61 @@ PIDPATH=/var/run
 tunnel_id=1
 
 missing() {
-	echo "Not starting tunneldigger - missing $1" >&2
+	echo "Not starting tunneldigger \"$1\" - missing $2" >&2
 }
 
-config_cb() {
-	local cfg="$CONFIG_SECTION"
-	config_get configname "$cfg" TYPE
-	case "$configname" in
-		broker)
-			config_get_bool enabled "$cfg" enabled 1
-			config_get addresses "$cfg" address
-			config_get uuid "$cfg" uuid
-			config_get interface "$cfg" interface
-			config_get limit_bw_down "$cfg" limit_bw_down
-			config_get hook_script "$cfg" hook_script
-			config_get bind_interface "$cfg" bind_interface
+handle_td() {
+	local cfg=$1
+	local enabled
+	local addresses
+	local uuid
+	local interface
+	local limit_bw_down
+	local hook_script
+	local bind_interface
+
+	config_get_bool enabled "$cfg" enabled 1
+	config_get addresses "$cfg" address
+	config_get uuid "$cfg" uuid
+	config_get interface "$cfg" interface
+	config_get limit_bw_down "$cfg" limit_bw_down
+	config_get hook_script "$cfg" hook_script
+	config_get bind_interface "$cfg" bind_interface
 			
-			[ $enabled -eq 0 ] && return
+	[ $enabled -eq 0 ] && return
 
-			local broker_opts=""
-			for address in $addresses; do
-			  append broker_opts "-b ${address}"
-			done
+	local broker_opts=""
+	local address
+	for address in $addresses; do
+		append broker_opts "-b ${address}"
+	done
 
-			[ ! -z "${limit_bw_down}" ] && append broker_opts "-L ${limit_bw_down}"
-			[ ! -z "${hook_script}" ] && append broker_opts "-s ${hook_script}"
-			[ ! -z "${bind_interface}" ] && {
-				# Resolve logical interface name.
-				unset _bind_interface
-				network_get_device _bind_interface "${bind_interface}" || _bind_interface="${bind_interface}"
-				append broker_opts "-I ${_bind_interface}"
-			}
+	[ ! -z "${limit_bw_down}" ] && append broker_opts "-L ${limit_bw_down}"
+	[ ! -z "${hook_script}" ] && append broker_opts "-s ${hook_script}"
+	[ ! -z "${bind_interface}" ] && {
+		# Resolve logical interface name.
+		unset _bind_interface
+		network_get_device _bind_interface "${bind_interface}" || _bind_interface="${bind_interface}"
+		append broker_opts "-I ${_bind_interface}"
+	}
 
-			if [ -z "$uuid" ]; then
-				missing uuid
-				return
-			elif [ -z "$interface" ]; then
-				missing interface
-				return
-			fi
+	if [ -z "$uuid" ]; then
+		missing $cfg uuid
+		return
+	elif [ -z "$interface" ]; then
+		missing $cfg interface
+		return
+	fi
 
-			echo "Starting tunneldigger on ${interface}"
-			/sbin/start-stop-daemon -S -q -b -m -p ${PIDPATH}/tunneldigger.${interface}.pid -x /usr/bin/tunneldigger -- -u ${uuid} -i ${interface} -t ${tunnel_id} ${broker_opts}
+	echo "Starting tunneldigger \"$cfg\" on ${interface}"
+	/sbin/start-stop-daemon -S -q -b -m -p ${PIDPATH}/tunneldigger.${interface}.pid -x /usr/bin/tunneldigger -- -u ${uuid} -i ${interface} -t ${tunnel_id} ${broker_opts}
 
-			let tunnel_id++
-		;;
-	esac
+	let tunnel_id++
 }
 
 start() {
 	config_load tunneldigger
+	config_foreach handle_td broker
 }
 
 stop() {


### PR DESCRIPTION
The init script was not successfully starting tunneldigger when there
were multiple tunneldigger sections specified in the config file. The
config_cb has been substitued with a handle_td function which is called
with a config_foreach, thereby simplifying the script.

Signed-off-by: pmelange <isprotejesvalkata@gmail.com>